### PR TITLE
Count a user registered only when approved

### DIFF
--- a/backend/controllers/event.controller.js
+++ b/backend/controllers/event.controller.js
@@ -151,8 +151,7 @@ module.exports.getRegistrationCount = async (req, res, next) => {
             return res.status(404).json({ message: "Event not found" });
         }
 
-        const registrationCount = await RegistrationModel.countDocuments({ eventId: event._id });
-
+        const registrationCount = await RegistrationModel.countDocuments({ eventId: event._id, approved: true });
         res.status(200).json({ count: registrationCount });
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Pull Request Description
Previously, even when a user registered, they were automatically counted as approved users, which blocked the limit of users. The count of authorised users is updated only when a user is authorised.

### Related Issue
Fixes # NA

## Checklist

 - [x] Tests -
 - [x] Documentation -
 - [x] Lint checks pass -
 - [x] Self-reviewed my code -
 - [x] Added proper comments -
